### PR TITLE
Add russian translate for quick settings group

### DIFF
--- a/extension/po/ru.po
+++ b/extension/po/ru.po
@@ -49,16 +49,16 @@ msgstr "Сбросить по умолчанию"
 
 #: extension/extension.js:137
 msgid "Privacy"
-msgstr ""
+msgstr "Конфиденциальность"
 
 #: extension/extension.js:219
 msgid "All disabled"
-msgstr ""
+msgstr "Всё отключено"
 
 #. Translators: this displays which setting is enabled, e.g. 'Location enabled'
 #: extension/extension.js:226
 msgid " enabled"
-msgstr ""
+msgstr " включено"
 
 #: extension/prefs.js:127
 msgid "Settings"
@@ -90,43 +90,43 @@ msgstr "Использовать меню быстрых настроек вме
 
 #: extension/prefs.js:139
 msgid "Group quick settings"
-msgstr ""
+msgstr "Группировать быстрые настройки"
 
 #: extension/prefs.js:139
 msgid "Group quick settings together, into a menu"
-msgstr ""
+msgstr "Сгруппируйте быстрые настройки"
 
 #: extension/prefs.js:140
 msgid "Use quick settings subtitle"
-msgstr ""
+msgstr "Использовать подзаголовок группы"
 
 #: extension/prefs.js:140
 msgid "Show the privacy status in the quick settings subtitle"
-msgstr ""
+msgstr "Показывать статус конфиденциальности в подзаголовке группы"
 
 #: extension/prefs.js:149
 msgid "Report an issue"
-msgstr ""
+msgstr "Сообщить о проблеме"
 
 #: extension/prefs.js:149
 msgid "GitHub issue tracker"
-msgstr ""
+msgstr "Трекер проблем GitHub"
 
 #: extension/prefs.js:150
 msgid "Donate via GitHub"
-msgstr ""
+msgstr "Пожертвовать через GitHub"
 
 #: extension/prefs.js:150
 msgid "Become a sponsor"
-msgstr ""
+msgstr "Стать спонсором"
 
 #: extension/prefs.js:151
 msgid "Donate via PayPal"
-msgstr ""
+msgstr "Пожертвовать через PayPal"
 
 #: extension/prefs.js:151
 msgid "Thanks for your support :)"
-msgstr ""
+msgstr "Спасибо за вашу поддержку :)"
 
 #: extension/prefs.js:153
 msgid "Links"

--- a/extension/po/ru.po
+++ b/extension/po/ru.po
@@ -2,14 +2,15 @@
 # Copyright (C) 2022 Stuart Hayhurst
 # This file is distributed under the same license as the privacy-menu-extension package.
 # Vyacheslav Kostromin <ikibastusloh1337@gmail.com>, 2022.
+# Dmitry Maksimetny <maksimetny@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: privacy-menu-extension\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-08-20 19:26+0100\n"
-"PO-Revision-Date: 2022-10-09 02:20+0700\n"
-"Last-Translator: Vyacheslav Kostromin <ikibastusloh1337@gmail.com>\n"
+"PO-Revision-Date: 2024-01-11 20:00+0100\n"
+"Last-Translator: Dmitry Maksimetny <maksimetny@gmail.com>\n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
@@ -94,11 +95,11 @@ msgstr "Группировать быстрые настройки"
 
 #: extension/prefs.js:139
 msgid "Group quick settings together, into a menu"
-msgstr "Сгруппируйте быстрые настройки"
+msgstr "Объедините быстрые настройки в меню"
 
 #: extension/prefs.js:140
 msgid "Use quick settings subtitle"
-msgstr "Использовать подзаголовок группы"
+msgstr "Использовать подзаголовок группы быстрых настроек"
 
 #: extension/prefs.js:140
 msgid "Show the privacy status in the quick settings subtitle"


### PR DESCRIPTION
This adds russian translation to a group of quick settings (in `ru.po`) which may be useful for users who prefer Russian language